### PR TITLE
feat: bump python-multipart to 0.0.22 (fix high CVE-2026-24486)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -62,7 +62,7 @@
 | [python-json-logger](https://nhairs.github.io/python-json-logger) | 3.3.0 | python3_extratools |
 | [python-lsp-jsonrpc](https://github.com/python-lsp/python-lsp-jsonrpc) | 1.1.2 | python3_extratools |
 | [python-lsp-server](https://github.com/python-lsp/python-lsp-server) | 1.12.2 | python3_extratools |
-| [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.20 | python3_extratools |
+| [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.22 | python3_extratools |
 | [python-pptx](https://github.com/scanny/python-pptx) | 1.0.2 | python3_extratools |
 | [pyxml2pdf](https://github.com/BjoernLudwigPTB/pyxml2pdf) | 0.3.5 | python3_extratools |
 | [pyzmq](https://pyzmq.readthedocs.org) | 26.4.0 | python3_extratools |

--- a/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
@@ -55,7 +55,7 @@ pypdf==6.6.0
 python-json-logger==3.3.0
 python-lsp-jsonrpc==1.1.2
 python-lsp-server==1.12.2
-python-multipart==0.0.20
+python-multipart==0.0.22
 python-pptx==1.0.2
 pyxml2pdf==0.3.5
 reportlab==4.4.0


### PR DESCRIPTION
Close: https://github.com/metwork-framework/mfextaddon_extratools/security/dependabot/10