### PR TITLE
feat: bump pypdf from 6.6.2 to 6.7.5 (fix several CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -58,7 +58,7 @@
 | [overrides](https://github.com/mkorpela/overrides) | 7.7.0 | python3_extratools |
 | [pandocfilters](http://github.com/jgm/pandocfilters) | 1.5.1 | python3_extratools |
 | [prometheus_client](https://github.com/prometheus/client_python) | 0.21.1 | python3_extratools |
-| [pypdf](https://pypi.org/project/pypdf) | 6.6.0 | python3_extratools |
+| [pypdf](https://pypi.org/project/pypdf) | 6.7.5 | python3_extratools |
 | [python-json-logger](https://nhairs.github.io/python-json-logger) | 3.3.0 | python3_extratools |
 | [python-lsp-jsonrpc](https://github.com/python-lsp/python-lsp-jsonrpc) | 1.1.2 | python3_extratools |
 | [python-lsp-server](https://github.com/python-lsp/python-lsp-server) | 1.12.2 | python3_extratools |

--- a/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
@@ -51,7 +51,7 @@ openpyxl==3.1.5
 overrides==7.7.0
 pandocfilters==1.5.1
 prometheus-client==0.21.1
-pypdf==6.6.0
+pypdf==6.7.5
 python-json-logger==3.3.0
 python-lsp-jsonrpc==1.1.2
 python-lsp-server==1.12.2


### PR DESCRIPTION
CVE fixed :
- CVE-2026-27024 (moderate, fixed in 6.7.1)
- CVE-2026-27025 (moderate, fixed in 6.7.1)
- CVE-2026-27026 (moderate, fixed in 6.7.1)
- CVE-2026-27628 (low, fixed in 6.7.2)
- CVE-2026-27888 (moderate, fixed in 6.7.3)
- CVE-2026-28351 (moderate, fixed in 6.7.4)