### PR TITLE
feat: bump pypdf from 6.7.5 to 6.9.1 (fix moderate CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -61,7 +61,7 @@
 | [pandocfilters](http://github.com/jgm/pandocfilters) | 1.5.1 | python3_extratools |
 | [prometheus_client](https://github.com/prometheus/client_python) | 0.21.1 | python3_extratools |
 | [pycairo](https://pycairo.readthedocs.io) | 1.29.0 | python3_extratools |
-| [pypdf](https://pypi.org/project/pypdf) | 6.7.5 | python3_extratools |
+| [pypdf](https://pypi.org/project/pypdf) | 6.9.1 | python3_extratools |
 | [python-json-logger](https://nhairs.github.io/python-json-logger) | 3.3.0 | python3_extratools |
 | [python-lsp-jsonrpc](https://github.com/python-lsp/python-lsp-jsonrpc) | 1.1.2 | python3_extratools |
 | [python-lsp-server](https://github.com/python-lsp/python-lsp-server) | 1.12.2 | python3_extratools |

--- a/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
@@ -54,7 +54,7 @@ overrides==7.7.0
 pandocfilters==1.5.1
 prometheus-client==0.21.1
 pycairo==1.29.0
-pypdf==6.7.5
+pypdf==6.9.1
 python-json-logger==3.3.0
 python-lsp-jsonrpc==1.1.2
 python-lsp-server==1.12.2


### PR DESCRIPTION
fix CVE-2026-31826 and CVE-2026-33123