### PR TITLE
feat: bump jupyter_server from 2.16.0 to 2.18.2 (fix high CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -32,7 +32,7 @@
 | [jupyter](https://jupyter.org) | 1.1.1 | python3_extratools |
 | [jupyter_client](https://jupyter.org) | 8.6.3 | python3_extratools |
 | [jupyter_core](https://jupyter.org) | 5.7.2 | python3_extratools |
-| [jupyter_server](https://jupyter-server.readthedocs.io) | 2.16.0 | python3_extratools |
+| [jupyter_server](https://jupyter-server.readthedocs.io) | 2.18.2 | python3_extratools |
 | [jupyter_server_proxy](https://pypi.org/project/jupyter_server_proxy) | 4.4.0 | python3_extratools |
 | [jupyter_server_terminals](https://jupyter.org) | 0.5.3 | python3_extratools |
 | [jupyterlab](https://jupyter.org) | 4.5.7 | python3_extratools |

--- a/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
@@ -30,7 +30,7 @@ jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.12.0
 jupyter-lsp==2.2.5
-jupyter-server==2.16.0
+jupyter-server==2.18.2
 jupyter-server-proxy==4.4.0
 jupyter-server-terminals==0.5.3
 jupyterlab==4.5.7


### PR DESCRIPTION
CVE fixed : 
- CVE-2026-35397 (high)
- CVE-2026-40934 (high)
- CVE-2026-40110  (high)
- CVE-2025-61669 (moderate)