### PR TITLE
feat: bump jupyterlab from 4.5.9 to 4.5.10 (fix 2 high GHSA)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -35,7 +35,7 @@
 | [jupyter_server](https://jupyter-server.readthedocs.io) | 2.20.0 | python3_extratools |
 | [jupyter_server_proxy](https://pypi.org/project/jupyter_server_proxy) | 4.4.0 | python3_extratools |
 | [jupyter_server_terminals](https://jupyter.org) | 0.5.3 | python3_extratools |
-| [jupyterlab](https://jupyter.org) | 4.5.9 | python3_extratools |
+| [jupyterlab](https://jupyter.org) | 4.5.10 | python3_extratools |
 | [jupyterlab_pygments](https://github.com/jupyterlab/jupyterlab_pygments) | 0.3.0 | python3_extratools |
 | [jupyterlab_server](https://jupyterlab-server.readthedocs.io) | 2.28.0 | python3_extratools |
 | [jupyterlab_widgets](https://github.com/jupyter-widgets/ipywidgets) | 3.0.15 | python3_extratools |

--- a/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_extratools/0500_extra_packages/requirements3.txt
@@ -33,7 +33,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.20.0
 jupyter-server-proxy==4.4.0
 jupyter-server-terminals==0.5.3
-jupyterlab==4.5.9
+jupyterlab==4.5.10
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.28.0
 jupyterlab_widgets==3.0.15


### PR DESCRIPTION
GHSA fixed :
- GHSA-gx64-gj6p-pc4c (high)
- GHSA-pppj-hq3g-57pj (high)
- GHSA-89vp-jrxv-24w8 (moderate)
- GHSA-h5v5-8746-g7mm (moderate)
- GHSA-whvh-wf3x-g77j (low)